### PR TITLE
Improved grammars

### DIFF
--- a/grammars/dotenv.cson
+++ b/grammars/dotenv.cson
@@ -5,6 +5,24 @@
 ]
 'patterns': [
   {
+    'match': '^(?:(export)\\s+)?(?:([\\w\\.]+)(?:\\s*(=)\\s*)(?:([^\'"#\\s\\n]+)|(\'(?:\\\'|[^\'])*\')|(\"(?:\\\"|[^\"])*\"))?\\s*|\\s+)(?:\\s*(#.*))?$'
+    'captures':
+      '1':
+        'name': 'storage.modifier.export.dotenv'
+      '2':
+        'name': 'constant.language.dotenv'
+      '3':
+        'name': 'keyword.operator.dotenv'
+      '4':
+        'name': 'string.dotenv'
+      '5':
+        'name': 'string.quoted.single.dotenv'
+      '6':
+        'name': 'string.quoted.double.dotenv'
+      '7':
+        'name': 'comment.dotenv'
+  },
+  {
     'match': '^#.*$'
     'name': 'comment.line.dotenv'
   }

--- a/spec/dotenv-spec.coffee
+++ b/spec/dotenv-spec.coffee
@@ -12,9 +12,77 @@ describe "dotenv file grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.dotenv"
 
-  it "tokenizes comments", ->
+  it "parses simple declarations", ->
+    {tokens} = grammar.tokenizeLine("FOO=BAR")
+    expect(tokens[0]).toEqual value: "FOO", scopes: ["source.dotenv", "constant.language.dotenv"]
+    expect(tokens[1]).toEqual value: "=", scopes: ["source.dotenv", "keyword.operator.dotenv"]
+    expect(tokens[2]).toEqual value: "BAR", scopes: ["source.dotenv", "string.dotenv"]
+
+  it "parses quoted declarations", ->
+    {tokens} = grammar.tokenizeLine("FOO='BAR'")
+    expect(tokens[0]).toEqual value: "FOO", scopes: ["source.dotenv", "constant.language.dotenv"]
+    expect(tokens[1]).toEqual value: "=", scopes: ["source.dotenv", "keyword.operator.dotenv"]
+    expect(tokens[2]).toEqual value: "'BAR'", scopes: ["source.dotenv", "string.quoted.single.dotenv"]
+
+    {tokens} = grammar.tokenizeLine("FOO=\"BAR\"")
+    expect(tokens[0]).toEqual value: "FOO", scopes: ["source.dotenv", "constant.language.dotenv"]
+    expect(tokens[1]).toEqual value: "=", scopes: ["source.dotenv", "keyword.operator.dotenv"]
+    expect(tokens[2]).toEqual value: "\"BAR\"", scopes: ["source.dotenv", "string.quoted.double.dotenv"]
+
+  it "ignores trailing whitespace after declaration", ->
+    {tokens} = grammar.tokenizeLine("FOO=BAR ")
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.dotenv"]
+
+    {tokens} = grammar.tokenizeLine("FOO='BAR' ")
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.dotenv"]
+
+    {tokens} = grammar.tokenizeLine("FOO=\"BAR\" ")
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.dotenv"]
+
+  it "parses whitespaces around the equal sign", ->
+    {tokens} = grammar.tokenizeLine("FOO = BAR")
+    expect(tokens[0]).toEqual value: "FOO", scopes: ["source.dotenv", "constant.language.dotenv"]
+    expect(tokens[2]).toEqual value: "=", scopes: ["source.dotenv", "keyword.operator.dotenv"]
+    expect(tokens[4]).toEqual value: "BAR", scopes: ["source.dotenv", "string.dotenv"]
+
+  it "parses variable names with punctuation", ->
+    {tokens} = grammar.tokenizeLine("F.OO=BAR")
+    expect(tokens[0]).toEqual value: "F.OO", scopes: ["source.dotenv", "constant.language.dotenv"]
+    expect(tokens[1]).toEqual value: "=", scopes: ["source.dotenv", "keyword.operator.dotenv"]
+    expect(tokens[2]).toEqual value: "BAR", scopes: ["source.dotenv", "string.dotenv"]
+
+  it "parses empty declarations", ->
+    {tokens} = grammar.tokenizeLine("FOO=")
+    expect(tokens[0]).toEqual value: "FOO", scopes: ["source.dotenv", "constant.language.dotenv"]
+    expect(tokens[1]).toEqual value: "=", scopes: ["source.dotenv", "keyword.operator.dotenv"]
+
+  it "parses export statements", ->
+    {tokens} = grammar.tokenizeLine("export FOO=BAR")
+    expect(tokens[0]).toEqual value: "export", scopes: ["source.dotenv", "storage.modifier.export.dotenv"]
+    expect(tokens[2]).toEqual value: "FOO", scopes: ["source.dotenv", "constant.language.dotenv"]
+    expect(tokens[3]).toEqual value: "=", scopes: ["source.dotenv", "keyword.operator.dotenv"]
+    expect(tokens[4]).toEqual value: "BAR", scopes: ["source.dotenv", "string.dotenv"]
+
+  it "parses inline comments", ->
+    {tokens} = grammar.tokenizeLine("FOO=BAR # BAZ")
+    expect(tokens[4]).toEqual value: "# BAZ", scopes: ["source.dotenv", "comment.dotenv"]
+
+    {tokens} = grammar.tokenizeLine(" # BAZ")
+    expect(tokens[1]).toEqual value: "# BAZ", scopes: ["source.dotenv", "comment.dotenv"]
+
+  it "parses whole line comments", ->
     {tokens} = grammar.tokenizeLine("# FOO=BAR")
     expect(tokens[0]).toEqual value: "# FOO=BAR", scopes: ["source.dotenv", "comment.line.dotenv"]
+
+  it "doesn't parse comments in quotes", ->
+    {tokens} = grammar.tokenizeLine("FOO='#' # BAR")
+    expect(tokens[4]).toEqual value: "# BAR", scopes: ["source.dotenv", "comment.dotenv"]
+
+    {tokens} = grammar.tokenizeLine("FOO=\"#\" # BAR")
+    expect(tokens[4]).toEqual value: "# BAR", scopes: ["source.dotenv", "comment.dotenv"]
+
+    {tokens} = grammar.tokenizeLine("FOO='\'#' # BAR")
+    expect(tokens[4]).toEqual value: "# BAR", scopes: ["source.dotenv", "comment.dotenv"]
 
 describe "dotenv sets config ", ->
   it "sets an array of filenames in config", ->


### PR DESCRIPTION
Have made a quite large improvement to the plugin, by adding better parsing and
scoping of dotenv-files. This commits includes the following:

* Added support for inline comments
* Added support for 'export' keyword
* Added scopes to the keys, values and operator
* Added support for quoted values
* Updated and added specs for all features